### PR TITLE
Remove constants that are deprecated in HA 2025.1

### DIFF
--- a/custom_components/torque_logger/device_tracker.py
+++ b/custom_components/torque_logger/device_tracker.py
@@ -6,7 +6,7 @@ import logging
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.components.device_tracker.const import (
     DOMAIN,
-    SOURCE_TYPE_GPS,
+    SourceType,
 )
 from homeassistant.const import (
     ATTR_LATITUDE,
@@ -106,7 +106,7 @@ class TorqueDeviceTracker(TorqueEntity, TrackerEntity, RestoreEntity):
     @property
     def source_type(self):
         """Return the source type, eg gps or router, of the device."""
-        return SOURCE_TYPE_GPS
+        return SourceType.GPS
 
     async def async_added_to_hass(self):
         """Call when entity about to be added to Home Assistant."""


### PR DESCRIPTION
HA asks to remove `SOURCE_TYPE_GPS` and instead use `SourceType.GPS`.

**Log**
`SOURCE_TYPE_GPS was used from torque_logger, this is a deprecated constant which will be removed in HA Core 2025.1. Use SourceType.GPS instead, please create a bug report at https://github.com/junalmeida/homeassistant-torque/issues`